### PR TITLE
Added Q2DLL_EXPORT support for macOS

### DIFF
--- a/rerelease/game.h
+++ b/rerelease/game.h
@@ -102,7 +102,7 @@ constexpr bit_t<n> bit_v = 1ull << n;
 
 #if defined(_WIN32)
     #define Q2DLL_EXPORT   __declspec( dllexport )
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     #define Q2DLL_EXPORT   __attribute__((visibility("default")))
 #else
     #define Q2DLL_EXPORT


### PR DESCRIPTION
Add macOS to the list of platforms which must export symbols with `__attribute__((visibility("default")))`, otherwise the library builds cleanly but can not be loaded by the main executable.