### PR TITLE
Add __APPLE__ to Q2DLL_EXPORT visibility branch

### DIFF
--- a/rerelease/game.h
+++ b/rerelease/game.h
@@ -102,7 +102,7 @@ constexpr bit_t<n> bit_v = 1ull << n;
 
 #if defined(_WIN32)
     #define Q2DLL_EXPORT   __declspec( dllexport )
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     #define Q2DLL_EXPORT   __attribute__((visibility("default")))
 #else
     #define Q2DLL_EXPORT


### PR DESCRIPTION
Without this, the visibility("default") attribute is not applied on macOS, so with -fvisibility=hidden the GetGameAPI/GetCGameAPI entry points become local symbols and dlsym() in the loader fails to find them.